### PR TITLE
Fix CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
+      with:
+        submodules: true
     - name: Package update
       run: swift package update
     - name: Build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
+    - name: Package update
+      run: swift package update
     - name: Build
       run: swift build -v
     - name: Run tests on iOS

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,5 +13,7 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
+    - name: Build
+      run: swift build -v
     - name: Run tests on iOS
-      run:  xcodebuild clean test -scheme xxHash-Swift -destination "platform=iOS Simulator,OS=15.0,name=iPhone 13"
+      run:  xcodebuild clean test -scheme xxHash-Swift -destination "platform=iOS Simulator,OS=15.2,name=iPhone 13"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,5 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
-    - name: Build
-      run: swift build -v
     - name: Run tests on iOS
-      run:  xcodebuild clean test -scheme xxHash-Swift -destination "platform=iOS Simulator,OS=16.0,name=iPhone 14"
+      run:  xcodebuild clean test -scheme xxHash-Swift -destination "platform=iOS Simulator,OS=15.0,name=iPhone 13"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,3 +21,5 @@ jobs:
       run: swift build -v
     - name: Run tests on iOS
       run:  xcodebuild clean test -scheme xxHash-Swift -destination "platform=iOS Simulator,OS=15.2,name=iPhone 13"
+    - name: Run tests on macOS
+      run:  xcodebuild clean test -scheme xxHash-Swift -destination "platform=macOS"

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 5.7
+// swift-tools-version: 5.5
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription


### PR DESCRIPTION
fix ci

current latest Xcode version of github action is 13, so it doesn't support iOS 16

Errors:
```
package at '/Users/runner/work/xxHash-Swift/xxHash-Swift' is using Swift tools version 5.7.0 but the installed version is 5.5.0
```

Checkout submodule
refer to:
https://stackoverflow.com/questions/59271919/how-to-clone-public-submodule-in-github-actions