### PR TITLE
Update ci.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,9 +17,11 @@ jobs:
         submodules: true
     - name: Package update
       run: swift package update
-    - name: Build
-      run: swift build -v
-    - name: Run tests on iOS
-      run:  xcodebuild clean test -scheme xxHash-Swift -destination "platform=iOS Simulator,OS=15.2,name=iPhone 13"
-    - name: Run tests on macOS
-      run:  xcodebuild clean test -scheme xxHash-Swift -destination "platform=macOS"
+    - name: Swift Build
+      run: swift build -v -c release --arch arm64 --arch x86_64
+    - name: Swift Test
+      run: swift test -v -c release
+#     - name: Run tests on iOS
+#       run:  xcodebuild clean test -scheme xxHash-Swift -destination "platform=iOS Simulator,OS=15.2,name=iPhone 13"
+#     - name: Run tests on macOS
+#       run:  xcodebuild clean test -scheme xxHash-Swift -destination "platform=macOS"


### PR DESCRIPTION
1. swift build on different archs
2. use swift test which is faster than`xcodebuild`, which is  unnecessary because there is no dependencies on Apple Modules

refer to
https://github.com/apple/swift-package-manager/blob/main/Documentation/Usage.md#depending-on-apple-modules